### PR TITLE
Remove `moniteringInterval` field

### DIFF
--- a/CloudEnvironment2.yml
+++ b/CloudEnvironment2.yml
@@ -11,7 +11,6 @@ datacenters:
     lowerUtilizationThreshold: 0.2
     vmMigration: enabled
     schedulingInterval: 30
-    monitoringInterval: 180
     costPerSec: 0.1
     costPerMem: 0.05
     costPerStorage: 0.001

--- a/CloudEnvironment3.yml
+++ b/CloudEnvironment3.yml
@@ -11,7 +11,6 @@ datacenters:
     lowerUtilizationThreshold: 0.2
     vmMigration: enabled
     schedulingInterval: 30
-    monitoringInterval: 180
     costPerSec: 0.1
     costPerMem: 0.05
     costPerStorage: 0.001
@@ -68,7 +67,6 @@ datacenters:
     lowerUtilizationThreshold: 0.2
     vmMigration: enabled
     schedulingInterval: 30
-    monitoringInterval: 180
     costPerSec: 0.1
     costPerMem: 0.05
     costPerStorage: 0.001


### PR DESCRIPTION
Cloud scenario YAML files with field `monitoringInterval` would fail to parse.
This field doesn't exist in CloudSim Plus Datacenter and should be removed.